### PR TITLE
Add support for `action` param on POST

### DIFF
--- a/pine_client/client.py
+++ b/pine_client/client.py
@@ -245,6 +245,8 @@ class Params(TypedDict, total=False):
     passthrough_by_method: Dict[ODataMethod, AnyObject]
     options: ODataOptions
 
+class PostParams(Params, total=False):
+    action: str
 
 class GetOrCreateParams(TypedDict):
     api_prefix: NotRequired[str]
@@ -854,7 +856,7 @@ class PinejsClientCore(ABC):
     def patch(self, params: Params) -> Any:
         return self.request({**params, "method": "PATCH"})
 
-    def post(self, params: Params) -> Any:
+    def post(self, params: PostParams) -> Any:
         return self.request({**params, "method": "POST"})
 
     def delete(self, params: Params) -> Any:
@@ -936,7 +938,7 @@ class PinejsClientCore(ABC):
 
             return self.patch(patch_parameters)
 
-    def request(self, params: Params) -> Any:
+    def request(self, params: Union[Params, PostParams]) -> Any:
         # TODO: actually passthrought the passthrought stuff
         api_prefix = params.get("api_prefix", self.api_prefix)
         url = api_prefix + self.compile(params)
@@ -947,7 +949,7 @@ class PinejsClientCore(ABC):
     def _request(self, method: str, url: str, body: Optional[Any] = None) -> Any:
         pass
 
-    def compile(self, params: Params) -> str:
+    def compile(self, params: Union[Params, PostParams]) -> str:
         url = params.get("url")
 
         if url is not None:
@@ -983,6 +985,10 @@ class PinejsClientCore(ABC):
                 value = "" if v is None else str(v)
 
             url += f"({value})"
+
+        action = params.get("action")
+        if action is not None:
+            url += f"/{action}"
 
         query_options: List[str] = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ typing-extensions = "^4.5.0"
 [tool.poetry.dev-dependencies]
 black = {version = "*", python = "^3.8.1"}
 flake8 = "*"
-pytest = "*"
+pytest = "8.0"
 
 
 [build-system]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,22 @@
+from .helper import assert_compile
+import pytest
+
+def test_bound_action():
+    assert_compile({
+        "resource": "a",
+        "id": 1,
+        "action": "act"
+    }, "a(1)/act")
+
+def test_unbound_action():
+    assert_compile({
+        "resource": "a",
+        "action": "act"
+    }, "a/act")
+
+def test_bound_action_with_named_id():
+    assert_compile({
+        "resource": "a",
+        "id": { "b": "c" },
+        "action": "act"
+    }, "a(b='c')/act")


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Project/Make-release-assets-publicly-available-and-maintained-1177
See: https://github.com/balena-io-modules/pinejs-client-js/pull/198

Change-type: minor